### PR TITLE
Update JAX dependency and add SLURM job script for DDM training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ dependencies = [
     "cmdstanpy>=1.2.5",
     "ipykernel>=6.29.5",
     # JAX - CPU version as base
-    "jax>=0.6.1",
+    "jax==0.6.1",
     # Platform-specific JAX with GPU support
-    "jax[cuda12-local]>=0.6.1 ; sys_platform == 'linux'",  # For Snellius (GPU)
+    # "jax[cuda12-local]>=0.6.1 ; sys_platform == 'linux'",  # For Snellius (GPU)
     "matplotlib>=3.10.3",
     "numba>=0.61.2",
     "numpy<=2.2.0",


### PR DESCRIPTION
- Changed JAX dependency in `pyproject.toml` to a fixed version for consistency.
- Commented out the platform-specific JAX GPU support dependency for Linux.
- Introduced `slurm_integrative_ddm_train.sh` for managing DDM training jobs, including CUDA module loading, logging, and automatic tool downloading.
- Enhanced job script with GPU checks and JAX installation verification for improved training setup.